### PR TITLE
[BE] feat: 검색 키워드 기반 공지사항 검색 기능 구현

### DIFF
--- a/backend/JiShop/src/main/java/com/jishop/controller/NoticeController.java
+++ b/backend/JiShop/src/main/java/com/jishop/controller/NoticeController.java
@@ -5,10 +5,12 @@ import com.jishop.dto.NoticeResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PagedModel;
+import org.springframework.http.ResponseEntity;
 
 @Tag(name = "공지사항 API")
 public interface NoticeController {
 
-    PagedModel<NoticeResponse> getAllNotices(Pageable pageable);
-    NoticeDetailResponse getNotice(Long id);
+    ResponseEntity<PagedModel<NoticeResponse>> getAllNotices(Pageable pageable);
+    ResponseEntity<NoticeDetailResponse> getNotice(Long id);
+    ResponseEntity<PagedModel<NoticeResponse>> searchNotices(String keyword, Pageable pageable);
 }

--- a/backend/JiShop/src/main/java/com/jishop/controller/impl/NoticeControllerImpl.java
+++ b/backend/JiShop/src/main/java/com/jishop/controller/impl/NoticeControllerImpl.java
@@ -9,6 +9,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.data.web.PagedModel;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -20,14 +21,22 @@ public class NoticeControllerImpl implements NoticeController {
 
     @Override
     @GetMapping
-    public PagedModel<NoticeResponse> getAllNotices(
-            @PageableDefault(page = 0, size = 15, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
-        return noticeService.getAllNotices(pageable);
+    public ResponseEntity<PagedModel<NoticeResponse>> getAllNotices(
+            @PageableDefault(size = 15, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+        return ResponseEntity.ok().body(noticeService.getAllNotices(pageable));
     }
 
     @Override
     @GetMapping("/{id}")
-    public NoticeDetailResponse getNotice(@PathVariable Long id) {
-        return noticeService.getNotice(id);
+    public ResponseEntity<NoticeDetailResponse> getNotice(@PathVariable Long id) {
+        return ResponseEntity.ok().body(noticeService.getNotice(id));
+    }
+
+    @Override
+    @GetMapping("/search")
+    public ResponseEntity<PagedModel<NoticeResponse>> searchNotices(
+            @RequestParam(required = false) String keyword,
+            @PageableDefault(size = 15, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+        return ResponseEntity.ok().body(noticeService.searchNotices(keyword, pageable));
     }
 }

--- a/backend/JiShop/src/main/java/com/jishop/repository/NoticeRepository.java
+++ b/backend/JiShop/src/main/java/com/jishop/repository/NoticeRepository.java
@@ -3,10 +3,13 @@ package com.jishop.repository;
 import com.jishop.common.exception.DomainException;
 import com.jishop.common.exception.ErrorType;
 import com.jishop.domain.Notice;
+import com.jishop.dto.NoticeResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.data.web.PagedModel;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -30,4 +33,11 @@ public interface NoticeRepository extends JpaRepository<Notice, Long> {
             "END DESC, " +
             "n.createdAt DESC")
     Page<Notice> findAll(Pageable pageable);
+
+    // 검색 키워드 기반 공지사항 조회
+        // 공지사항 게시글에 키워드가 포함된 경우
+        // 공지사항 제목에 키워드가 포함된 경우
+    @Query("SELECT n FROM Notice n WHERE n.title LIKE %:keyword% OR n.content LIKE %:keyword%")
+    Page<Notice> searchByKeyword(@Param("keyword")String keyword, Pageable pageable);
+
 }

--- a/backend/JiShop/src/main/java/com/jishop/service/NoticeService.java
+++ b/backend/JiShop/src/main/java/com/jishop/service/NoticeService.java
@@ -7,8 +7,7 @@ import org.springframework.data.web.PagedModel;
 
 public interface NoticeService {
 
-    // 공지사항 전체 목록 조회
     PagedModel<NoticeResponse> getAllNotices(Pageable pageable);
-    // 공지사항 상세 조회
     NoticeDetailResponse getNotice(Long id);
+    PagedModel<NoticeResponse> searchNotices(String keyword, Pageable pageable);
 }

--- a/backend/JiShop/src/main/java/com/jishop/service/impl/NoticeServiceImpl.java
+++ b/backend/JiShop/src/main/java/com/jishop/service/impl/NoticeServiceImpl.java
@@ -32,6 +32,7 @@ public class NoticeServiceImpl implements NoticeService {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public PagedModel<NoticeResponse> searchNotices(String keyword, Pageable pageable) {
         if(keyword == null || keyword.isBlank()){
             return new PagedModel<>(Page.empty());

--- a/backend/JiShop/src/main/java/com/jishop/service/impl/NoticeServiceImpl.java
+++ b/backend/JiShop/src/main/java/com/jishop/service/impl/NoticeServiceImpl.java
@@ -5,6 +5,7 @@ import com.jishop.dto.NoticeResponse;
 import com.jishop.repository.NoticeRepository;
 import com.jishop.service.NoticeService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PagedModel;
 import org.springframework.stereotype.Service;
@@ -28,5 +29,15 @@ public class NoticeServiceImpl implements NoticeService {
     @Transactional(readOnly = true)
     public NoticeDetailResponse getNotice(Long id) {
         return NoticeDetailResponse.from(noticeRepository.findOne(id));
+    }
+
+    @Override
+    public PagedModel<NoticeResponse> searchNotices(String keyword, Pageable pageable) {
+        if(keyword == null || keyword.isBlank()){
+            return new PagedModel<>(Page.empty());
+        }
+
+        return new PagedModel<>(noticeRepository.searchByKeyword(keyword, pageable)
+                .map(NoticeResponse::from));
     }
 }


### PR DESCRIPTION
<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- resolves #에는 발행한 이슈 번호를 기입해주세요 -->

- resolves #27 

---

### 🚀 어떤 기능을 구현했나요 ?
- 검색 키워드 기반 공지사항 검색 기능 구현
  - 검색 키워드가 공지사항 `본문` 에 포함된 경우
  - 검색 키워드가 공지사항 `제목` 에 포함된 경우

### 🔥 어떤 문제를 마주했나요 ?
- 검색 키워드가 `null`, `""`, `"    "` 인 경우 어떻게 처리할 것인가에 대한 고민

### ✨ 어떻게 해결했나요 ?
- `무신사`, `지그재그`, `29cm`를 참고
- `지그재그`의 경우 검색 결과가 없다는 페이지를 반환
<img src = "https://github.com/user-attachments/assets/5a6c68c7-bec1-4ec2-b9e1-3a6f184090ff" width = 80%>

- 이 부분을 차용해 검색 키워드가 `null`, `""`, `"    "`인 경우 빈 페이지를 반환하도록 코드 작성
```java
    @Override
    public PagedModel<NoticeResponse> searchNotices(String keyword, Pageable pageable) {
        if(keyword == null || keyword.isBlank()){
            return new PagedModel<>(Page.empty());
        }

        return new PagedModel<>(noticeRepository.searchByKeyword(keyword, pageable)
                .map(NoticeResponse::from));
    }
```


### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 다양한 의견 환영합니다 !!

### 📚 참고 자료 및 회고 
<!--참고 자료(ref) 링크 및 스크린샷, 구현 과정에 대한 회고-->
-
