### PR TITLE
[BE] 비회원과 회원의 주문 관련 엔드포인트 분리

### DIFF
--- a/backend/JiShop/src/main/java/com/jishop/order/controller/OrderController.java
+++ b/backend/JiShop/src/main/java/com/jishop/order/controller/OrderController.java
@@ -1,42 +1,29 @@
 package com.jishop.order.controller;
 
-import com.jishop.address.dto.AddressResponse;
-import com.jishop.member.annotation.CurrentUser;
 import com.jishop.member.domain.User;
 import com.jishop.order.dto.*;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "주문 API")
 public interface OrderController {
 
-    //회원, 비회원 주문
+    //회원 주문
     ResponseEntity<OrderResponse> createOrder(User user, OrderRequest orderRequest);
 
-    //회원 주문 상세 조회
-    ResponseEntity<OrderDetailPageResponse> getOrder(User user, Long orderId);
+    //회원 바로주문
+    ResponseEntity<OrderResponse> createInstantOrder(User user, InstantOrderRequest orderRequest);
 
     //회원 주문 목록 조회 페이징 처리
     ResponseEntity<Page<OrderResponse>> getOrderList(User user, String period, int page, int size);
 
+    //회원 주문 상세 조회
+    ResponseEntity<OrderDetailPageResponse> getOrder(User user, Long orderId);
+
     //회원 주문 취소
     ResponseEntity<String> cancelOrder(User user, Long orderId);
 
-    //회원, 비회원 바로 주문
-    ResponseEntity<OrderResponse> createInstantOrder(User user, InstantOrderRequest orderRequest);
-
-    //비회원 주문 상세 조회
-    ResponseEntity<OrderDetailPageResponse> getGuestOrderDetail(String orderNumber, String phone);
-
-    //비회원 주문 취소
-    ResponseEntity<String> cancelGuestOrder(String orderNumber, String phone);
-
     //회원 취소 상세페이지
     ResponseEntity<OrderCancelResponse> getOrderCancel(User user, Long orderId);
-
-    //비회원 취소 상세페이지
-    ResponseEntity<OrderCancelResponse> getGuestOrderCancel(String orderNumber, String phone);
 }

--- a/backend/JiShop/src/main/java/com/jishop/order/controller/OrderControllerImpl.java
+++ b/backend/JiShop/src/main/java/com/jishop/order/controller/OrderControllerImpl.java
@@ -1,9 +1,5 @@
 package com.jishop.order.controller;
 
-import com.jishop.address.dto.AddressResponse;
-import com.jishop.address.repository.AddressRepository;
-import com.jishop.common.exception.DomainException;
-import com.jishop.common.exception.ErrorType;
 import com.jishop.member.annotation.CurrentUser;
 import com.jishop.member.domain.User;
 import com.jishop.order.dto.*;
@@ -72,40 +68,11 @@ public class OrderControllerImpl implements OrderController {
         return ResponseEntity.ok(orderResponse);
     }
 
-    //비회원 주문 조회하기
-    @Override
-    @GetMapping("/guest/{orderNumber}")
-    public ResponseEntity<OrderDetailPageResponse> getGuestOrderDetail(@PathVariable String orderNumber,
-                                                                       @RequestParam String phone) {
-        OrderDetailPageResponse orderDetailList = orderService.getOrder(null, null, orderNumber, phone);
-
-        return ResponseEntity.ok(orderDetailList);
-    }
-
-    //비회원 주문 취소하기
-    @Override
-    @PatchMapping("/guest/{orderNumber}")
-    public ResponseEntity<String> cancelGuestOrder(@PathVariable String orderNumber,
-                                                   @RequestParam String phone) {
-        orderService.cancelOrder(null, null, orderNumber, phone);
-
-        return ResponseEntity.ok("주문이 취소되었습니다.");
-    }
-
     //회원 주문 취소 상세  페이지
     @Override
     @GetMapping("/getCancel/{orderId}")
     public ResponseEntity<OrderCancelResponse> getOrderCancel(@CurrentUser User user, @PathVariable Long orderId) {
         OrderCancelResponse orderCancelResponse = orderService.getCancelPage(user, orderId, null, null);
-
-        return ResponseEntity.ok(orderCancelResponse);
-    }
-
-    //비회원 주문 취소 상세 페이지
-    @Override
-    @GetMapping("/getGuestCancel/{orderNumber}")
-    public ResponseEntity<OrderCancelResponse> getGuestOrderCancel(@PathVariable String orderNumber, @RequestParam String phone){
-        OrderCancelResponse orderCancelResponse = orderService.getCancelPage(null, null, orderNumber, phone);
 
         return ResponseEntity.ok(orderCancelResponse);
     }

--- a/backend/JiShop/src/main/java/com/jishop/order/controller/OrderGuestController.java
+++ b/backend/JiShop/src/main/java/com/jishop/order/controller/OrderGuestController.java
@@ -1,0 +1,24 @@
+package com.jishop.order.controller;
+
+import com.jishop.order.dto.*;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "비회원 주문 API")
+public interface OrderGuestController {
+
+    //비회원 주문 생성
+    ResponseEntity<OrderResponse> createGuestOrder(OrderRequest orderRequest);
+
+    //비회원 바로 주문 생성
+    ResponseEntity<OrderResponse> createGuestInstantOrder(InstantOrderRequest orderRequest);
+
+    //비회원 주문 상세 조회
+    ResponseEntity<OrderDetailPageResponse> getGuestOrderDetail(String orderNumber, String phone);
+
+    //비회원 주문 취소
+    ResponseEntity<String> cancelGuestOrder(String orderNumber, String phone);
+
+    //비회원 취소 상세페이지
+    ResponseEntity<OrderCancelResponse> getGuestOrderCancel(String orderNumber, String phone);
+}

--- a/backend/JiShop/src/main/java/com/jishop/order/controller/OrderGuestControllerImpl.java
+++ b/backend/JiShop/src/main/java/com/jishop/order/controller/OrderGuestControllerImpl.java
@@ -1,0 +1,64 @@
+package com.jishop.order.controller;
+
+import com.jishop.order.dto.*;
+import com.jishop.order.service.OrderGuestService;
+import com.jishop.order.service.OrderService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/ordersGuest")
+public class OrderGuestControllerImpl implements OrderGuestController {
+
+    private final OrderService orderService;
+
+    //비회원 주문 생성
+    @Override
+    @PostMapping
+    public ResponseEntity<OrderResponse> createGuestOrder(@RequestBody @Valid OrderRequest orderRequest) {
+        OrderResponse orderResponse = orderService.createGuestOrder(orderRequest);
+
+        return ResponseEntity.ok(orderResponse);
+    }
+
+    //비회원 바로주문 생성
+    @Override
+    @PostMapping("/instant")
+    public ResponseEntity<OrderResponse> createGuestInstantOrder(@RequestBody @Valid InstantOrderRequest orderRequest) {
+        OrderResponse orderResponse = orderService.createGuestInstantOrder(orderRequest);
+
+        return ResponseEntity.ok(orderResponse);
+    }
+
+    //비회원 주문 조회하기
+    @Override
+    @GetMapping("/{orderNumber}")
+    public ResponseEntity<OrderDetailPageResponse> getGuestOrderDetail(@PathVariable String orderNumber,
+                                                                       @RequestParam String phone) {
+        OrderDetailPageResponse orderDetailList = orderService.getGuestOrder(orderNumber, phone);
+
+        return ResponseEntity.ok(orderDetailList);
+    }
+
+    //비회원 주문 취소하기
+    @Override
+    @PatchMapping("/{orderNumber}")
+    public ResponseEntity<String> cancelGuestOrder(@PathVariable String orderNumber,
+                                                   @RequestParam String phone) {
+        orderService.cancelGuestOrder(orderNumber, phone);
+
+        return ResponseEntity.ok("주문이 취소되었습니다.");
+    }
+
+    //비회원 주문 취소 상세 페이지
+    @Override
+    @GetMapping("/getCancel/{orderNumber}")
+    public ResponseEntity<OrderCancelResponse> getGuestOrderCancel(@PathVariable String orderNumber, @RequestParam String phone){
+        OrderCancelResponse orderCancelResponse = orderService.getGuestCancelPage(orderNumber, phone);
+
+        return ResponseEntity.ok(orderCancelResponse);
+    }
+}

--- a/backend/JiShop/src/main/java/com/jishop/order/dto/OrderRequest.java
+++ b/backend/JiShop/src/main/java/com/jishop/order/dto/OrderRequest.java
@@ -1,14 +1,14 @@
 package com.jishop.order.dto;
 
 import com.jishop.address.dto.AddressRequest;
-import com.jishop.member.domain.User;
-import com.jishop.order.domain.Order;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 
-import java.util.*;
+import java.util.List;
 
 public record OrderRequest(
+        @NotNull(message = "주소 정보는 필수입니다.")
         @Valid AddressRequest address,
         @NotEmpty(message = "주문 상품 목록은 비어있을 수 없습니다.")
         List<OrderDetailRequest> orderDetailRequestList

--- a/backend/JiShop/src/main/java/com/jishop/order/service/OrderGuestService.java
+++ b/backend/JiShop/src/main/java/com/jishop/order/service/OrderGuestService.java
@@ -1,0 +1,21 @@
+package com.jishop.order.service;
+
+import com.jishop.order.dto.*;
+
+public interface OrderGuestService {
+
+    // 비회원 주문 생성
+    OrderResponse createGuestOrder(OrderRequest guestOrderRequest);
+
+    // 비회원 바로 구매하기
+    OrderResponse createGuestInstantOrder(InstantOrderRequest guestInstantOrderRequest);
+
+    // 비회원 주문 조회
+    OrderDetailPageResponse getGuestOrder(String orderNumber, String phone);
+
+    // 비회원 주문 취소
+    void cancelGuestOrder(String orderNumber, String phone);
+
+    // 비회원 주문 취소 상세 페이지
+    OrderCancelResponse getGuestCancelPage(String orderNumber, String phone);
+}

--- a/backend/JiShop/src/main/java/com/jishop/order/service/OrderService.java
+++ b/backend/JiShop/src/main/java/com/jishop/order/service/OrderService.java
@@ -6,10 +6,18 @@ import org.springframework.data.domain.Page;
 
 public interface OrderService {
 
+    //회원
     OrderResponse createOrder(User user, OrderRequest orderRequest);
     OrderResponse createInstantOrder(User user, InstantOrderRequest instantOrderRequest);
     OrderDetailPageResponse getOrder(User user, Long orderId, String orderNumber, String phone);
     Page<OrderResponse> getPaginatedOrders(User user, String period, int page, int size);
     void cancelOrder(User user, Long orderId, String orderNumber, String phone);
     OrderCancelResponse getCancelPage(User user, Long orderId, String orderNumber, String phone);
+
+    //비회원
+    OrderResponse createGuestOrder(OrderRequest orderRequest);
+    OrderResponse createGuestInstantOrder(InstantOrderRequest orderRequest);
+    OrderDetailPageResponse getGuestOrder(String orderNumber, String phone);
+    void cancelGuestOrder(String orderNumber, String phone);
+    OrderCancelResponse getGuestCancelPage(String orderNumber, String phone);
 }

--- a/backend/JiShop/src/main/java/com/jishop/order/service/impl/OrderServiceImpl.java
+++ b/backend/JiShop/src/main/java/com/jishop/order/service/impl/OrderServiceImpl.java
@@ -20,33 +20,69 @@ public class OrderServiceImpl implements OrderService {
     private final OrderGetService orderGetService;
     private final OrderCancelService orderCancelService;
 
+    //회원 주문 생성
     @Override
     public OrderResponse createOrder(User user, OrderRequest orderRequest) {
         return orderCreationService.createOrder(user, orderRequest);
     }
 
+    //회원 바로 주문 생성
     @Override
     public OrderResponse createInstantOrder(User user, InstantOrderRequest instantOrderRequest) {
         return orderCreationService.createInstantOrder(user, instantOrderRequest);
     }
 
+    //회원 주문 상세 조회
     @Override
     public OrderDetailPageResponse getOrder(User user, Long orderId, String orderNumber, String phone) {
         return orderGetService.getOrder(user, orderId, orderNumber, phone);
     }
 
+    //회원 주문 목록 조회
     @Override
     public Page<OrderResponse> getPaginatedOrders(User user, String period, int page, int size) {
         return orderGetService.getPaginatedOrders(user, period, page, size);
     }
 
+    //회원, 비회원 주문 취소
     @Override
     public void cancelOrder(User user, Long orderId, String orderNumber, String phone) {
         orderCancelService.cancelOrder(user, orderId, orderNumber, phone);
     }
 
+    //회원, 비회원 주문 취소 상세 페이지 조회
     @Override
     public OrderCancelResponse getCancelPage(User user, Long orderId, String orderNumber, String phone) {
         return orderGetService.getCancelPage(user, orderId, orderNumber, phone);
+    }
+
+    //비회원 주문 생성
+    @Override
+    public OrderResponse createGuestOrder(OrderRequest orderRequest) {
+        return orderCreationService.createOrder(null, orderRequest);
+    }
+
+    //비회원 바로 주문 생성
+    @Override
+    public OrderResponse createGuestInstantOrder(InstantOrderRequest orderRequest) {
+        return orderCreationService.createInstantOrder(null, orderRequest);
+    }
+
+    //비회원 주문 상세 페이지
+    @Override
+    public OrderDetailPageResponse getGuestOrder(String orderNumber, String phone) {
+        return orderGetService.getOrder(null, null, orderNumber, phone);
+    }
+
+    //비회원 주문 취소
+    @Override
+    public void cancelGuestOrder(String orderNumber, String phone) {
+        orderCancelService.cancelOrder(null, null, orderNumber, phone);
+    }
+
+    //비회원 주문 취소 페이지 조회
+    @Override
+    public OrderCancelResponse getGuestCancelPage(String orderNumber, String phone) {
+        return orderGetService.getCancelPage(null, null, orderNumber, phone);
     }
 }


### PR DESCRIPTION
### 🚀 어떤 기능을 구현했나요 ?
- 비회원, 회원의 주문 엔드포인트를 분리했습니다!

### 🔥 어떤 문제를 마주했나요 ?
- `@CurrentUser`를 사용 + 로그인이 안되어있을 시에 로그인페이지로 이동 + 로그인페이지에 비회원 주문하기 순서로 비회원 주문생성이 진행되어 엔드포인트를 분리하게 되었습니다!

### ✨ 어떻게 해결했나요 ?
- 메서드는 추가로 만들지 않고, 존재하는 선에서 엔드포인트만 분리하여 코드가 많이 늘어나지는 않았습니다!

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 

### 📚 참고 자료 및 회고 
<!--참고 자료(ref) 링크 및 스크린샷, 구현 과정에 대한 회고-->
-
