### PR TITLE
[BE] feat: 문의사항 작성 및 조회 기능 구현

### DIFF
--- a/backend/JiShop/src/main/java/com/jishop/common/exception/ErrorType.java
+++ b/backend/JiShop/src/main/java/com/jishop/common/exception/ErrorType.java
@@ -12,8 +12,9 @@ public enum ErrorType {
     DATA_ALREADY_DELETED(HttpStatus.GONE, "이미 삭제된 데이터 입니다."),
     MATCH_NOT_USER(HttpStatus.NOT_FOUND, "해당 권한이 없는 유저입니다."),
     TYPE_NOT_FOUND(HttpStatus.BAD_REQUEST, "해당 접근 타입이 잘 못 되었습니다."),
+    LOGIN_REQUIRED(HttpStatus.UNAUTHORIZED, "로그인이 필요한 서비스입니다."),
 
-    // Redis
+    // REDIS
     REDIS_OPERATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "Redis 작업 중 오류가 발생했습니다."),
 
     // USER
@@ -28,6 +29,7 @@ public enum ErrorType {
     REVIEW_DUPLICATE(HttpStatus.CONFLICT, "이미 리뷰를 작성했습니다."),
     RATING_OUT_OF_RANGE(HttpStatus.BAD_REQUEST, "별점은 1~5점을 해야한다."),
     REVIEW_NOT_FOUND(HttpStatus.BAD_REQUEST, "작성하신 리뷰가 없습니다."),
+
     // NOTICE
     NOTICE_NOT_FOUND(HttpStatus.NOT_FOUND, "공지사항이 존재하지 않습니다."),
 
@@ -53,7 +55,7 @@ public enum ErrorType {
     ORDER_CANCEL_FAILED(HttpStatus.BAD_REQUEST,"주문 취소 중 오류가 발생했습니다"),
     ORDER_CANNOT_CANCEL_AFTER_SHIPPING(HttpStatus.BAD_REQUEST, "배송이 시작한 이후에는 주문 취소를 할 수 없습니다"),
 
-    //CART
+    // CART
     CART_ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "장바구니 상품을 찾을 수 없습니다."),
 
     // VALIDATION
@@ -67,14 +69,19 @@ public enum ErrorType {
     // STORE
     STORE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 스토어가 존재하지 않습니다"),
 
-    // Address,
+    // ADDRESS
     DEFAULTADDRESS_NOT_FOUND(HttpStatus.NOT_FOUND, "기본 배송지가 없습니다."),
     ADDRESS_NOT_FOUND(HttpStatus.NOT_FOUND, "없는 배송지 입니다."),
     DEFAULT_ADDRESS_REQUIRED(HttpStatus.NOT_FOUND, "기본 배송지가 꼭 필요합니다."),
 
-    //REDISSON
+    // REDISSON
     LOCK_ACQUISITION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "주문 저리 중 잠금 획득에 실패했습니다. 잠시 후 시도해주세요"),
-    CONCURRENT_ORDER_PROCESSING(HttpStatus.INTERNAL_SERVER_ERROR, "동시에 너무 많은 주문이 처리되고 있습니다. 잠시 후 다시 시도해주세요");
+    CONCURRENT_ORDER_PROCESSING(HttpStatus.INTERNAL_SERVER_ERROR, "동시에 너무 많은 주문이 처리되고 있습니다. 잠시 후 다시 시도해주세요"),
+
+    // QUESTION
+    QUESTION_CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 카테고리입니다."),
+    QUESTION_ORDER_NUMBER_REQUIRED(HttpStatus.BAD_REQUEST, "주문번호가 필수인 문의유형입니다."),
+    QUESTION_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 문의사항입니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/backend/JiShop/src/main/java/com/jishop/order/repository/OrderRepository.java
+++ b/backend/JiShop/src/main/java/com/jishop/order/repository/OrderRepository.java
@@ -66,6 +66,9 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
 
     Optional<Order> findByOrderNumberAndPhone(String orderNumber, String phone);
 
+    // 문의사항 작성에 필요한 메서드 정의
+    Optional<Order> findByOrderNumber(String orderNumber);
+
     //스케쥴러를 위한 쿼리
     @Modifying
     @Query("UPDATE Order o SET o.status = :newStatus " +

--- a/backend/JiShop/src/main/java/com/jishop/question/controller/QuestionController.java
+++ b/backend/JiShop/src/main/java/com/jishop/question/controller/QuestionController.java
@@ -6,10 +6,12 @@ import com.jishop.question.dto.QuestionResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 
+import java.util.List;
+
 @Tag(name = "문의사항 API")
 public interface QuestionController {
 
     ResponseEntity<?> createQuestion(QuestionRequest request, User user);
-    ResponseEntity<?> getMyQuestion(User user);
+    ResponseEntity<List<QuestionResponse>> getMyQuestion(User user);
     ResponseEntity<QuestionResponse> getQuestion(User user, Long id);
 }

--- a/backend/JiShop/src/main/java/com/jishop/question/controller/QuestionController.java
+++ b/backend/JiShop/src/main/java/com/jishop/question/controller/QuestionController.java
@@ -1,0 +1,15 @@
+package com.jishop.question.controller;
+
+import com.jishop.member.domain.User;
+import com.jishop.question.dto.QuestionRequest;
+import com.jishop.question.dto.QuestionResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "문의사항 API")
+public interface QuestionController {
+
+    ResponseEntity<?> createQuestion(QuestionRequest request, User user);
+    ResponseEntity<?> getMyQuestion(User user);
+    ResponseEntity<QuestionResponse> getQuestion(User user, Long id);
+}

--- a/backend/JiShop/src/main/java/com/jishop/question/controller/QuestionControllerImpl.java
+++ b/backend/JiShop/src/main/java/com/jishop/question/controller/QuestionControllerImpl.java
@@ -1,0 +1,57 @@
+package com.jishop.question.controller;
+
+import com.jishop.common.exception.DomainException;
+import com.jishop.common.exception.ErrorType;
+import com.jishop.member.annotation.CurrentUser;
+import com.jishop.member.domain.User;
+import com.jishop.question.dto.QuestionRequest;
+import com.jishop.question.dto.QuestionResponse;
+import com.jishop.question.service.QuestionService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/questions")
+public class QuestionControllerImpl implements QuestionController {
+
+    private final QuestionService questionService;
+
+    @Override
+    @PostMapping
+    public ResponseEntity<?> createQuestion(@RequestBody @Valid QuestionRequest request,
+                                                   @CurrentUser User user) {
+        if(user == null) {
+            throw new DomainException(ErrorType.LOGIN_REQUIRED);
+        }
+
+        Long questionId = questionService.createQuestion(request, user);
+
+        return ResponseEntity.created(URI.create("/questions/" + questionId)).build();
+    }
+
+    @Override
+    @GetMapping
+    public ResponseEntity<List<QuestionResponse>> getMyQuestion(@CurrentUser User user){
+        if(user == null) {
+            throw new DomainException(ErrorType.LOGIN_REQUIRED);
+        }
+
+        return questionService.getMyQuestion(user);
+    }
+
+    @Override
+    @GetMapping("/{id}")
+    public ResponseEntity<QuestionResponse> getQuestion(@CurrentUser User user, @PathVariable Long id) {
+        if(user == null) {
+            throw new DomainException(ErrorType.LOGIN_REQUIRED);
+        }
+
+        return questionService.getQuestion(user, id);
+    }
+}

--- a/backend/JiShop/src/main/java/com/jishop/question/domain/AnswerStatus.java
+++ b/backend/JiShop/src/main/java/com/jishop/question/domain/AnswerStatus.java
@@ -1,0 +1,6 @@
+package com.jishop.question.domain;
+
+public enum AnswerStatus {
+    WAITING,
+    ANSWERED
+}

--- a/backend/JiShop/src/main/java/com/jishop/question/domain/Question.java
+++ b/backend/JiShop/src/main/java/com/jishop/question/domain/Question.java
@@ -1,0 +1,68 @@
+package com.jishop.question.domain;
+
+import com.jishop.common.util.BaseEntity;
+import com.jishop.member.domain.User;
+import com.jishop.order.domain.Order;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Table(name = "questions")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Question extends BaseEntity {
+
+    @JoinColumn(name = "category_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private QuestionCategory questionCategory;
+
+    @JoinColumn(name = "user_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private User user;
+
+    @JoinColumn(name = "order_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Order order;
+
+    @Column(nullable = false)
+    private String questionContent;
+
+    // TODO : 문의사항 이미지 처리는 file, review쪽 참고
+    private String image1;
+
+    private String image2;
+
+    private String image3;
+
+    private String answerContent;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private AnswerStatus answerStatus;
+
+    private LocalDateTime answeredAt;
+
+    @Builder
+    public Question(QuestionCategory questionCategory, User user, Order order,
+                    String questionContent, String image1, String image2, String image3) {
+        this.questionCategory = questionCategory;
+        this.user = user;
+        this.order = order;
+        this.questionContent = questionContent;
+        this.image1 = image1;
+        this.image2 = image2;
+        this.image3 = image3;
+        this.answerStatus = AnswerStatus.WAITING;
+    }
+
+    public void updateAnswers(String answerContent, LocalDateTime answeredAt) {
+        this.answerContent = answerContent;
+        this.answeredAt = answeredAt;
+        this.answerStatus = AnswerStatus.ANSWERED;
+    }
+}

--- a/backend/JiShop/src/main/java/com/jishop/question/domain/QuestionCategory.java
+++ b/backend/JiShop/src/main/java/com/jishop/question/domain/QuestionCategory.java
@@ -1,0 +1,33 @@
+package com.jishop.question.domain;
+
+import com.jishop.common.util.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "question_categories")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class QuestionCategory extends BaseEntity {
+
+    @ManyToOne
+    @JoinColumn(name = "parent_id")
+    private QuestionCategory parentCategory;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    private boolean requireOrderNumber;
+
+    @Builder
+    public QuestionCategory(QuestionCategory parentCategory, String name, boolean requireOrderNumber) {
+        this.parentCategory = parentCategory;
+        this.name = name;
+        this.requireOrderNumber = requireOrderNumber;
+    }
+}
+

--- a/backend/JiShop/src/main/java/com/jishop/question/dto/QuestionRequest.java
+++ b/backend/JiShop/src/main/java/com/jishop/question/dto/QuestionRequest.java
@@ -1,0 +1,29 @@
+package com.jishop.question.dto;
+
+import com.jishop.member.domain.User;
+import com.jishop.order.domain.Order;
+import com.jishop.question.domain.Question;
+import com.jishop.question.domain.QuestionCategory;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record QuestionRequest(
+        @NotNull Long categoryId,
+        String orderId,
+        @NotBlank String content,
+        String image1,
+        String image2,
+        String image3
+) {
+    public static Question toEntity(QuestionRequest request, QuestionCategory category, User user, Order order) {
+        return Question.builder()
+                .questionCategory(category)
+                .user(user)
+                .order(order)
+                .questionContent(request.content())
+                .image1(request.image1())
+                .image2(request.image2())
+                .image3(request.image3())
+                .build();
+    }
+}

--- a/backend/JiShop/src/main/java/com/jishop/question/dto/QuestionResponse.java
+++ b/backend/JiShop/src/main/java/com/jishop/question/dto/QuestionResponse.java
@@ -1,0 +1,34 @@
+package com.jishop.question.dto;
+
+import com.jishop.question.domain.Question;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalDateTime;
+
+public record QuestionResponse(
+        Long categoryId,
+        String orderId,
+        String content,
+        String image1,
+        String image2,
+        String image3,
+        String answerContent,
+        String answerStatus,
+        LocalDateTime answeredAt
+
+) {
+    public static QuestionResponse fromQuestion(Question question) {
+        return new QuestionResponse(
+                question.getQuestionCategory().getId(),
+                question.getOrder() != null ? question.getOrder().getOrderNumber() : null,
+                question.getQuestionContent(),
+                question.getImage1(),
+                question.getImage2(),
+                question.getImage3(),
+                question.getAnswerContent(),
+                question.getAnswerStatus().name(),
+                question.getAnsweredAt()
+        );
+    }
+}

--- a/backend/JiShop/src/main/java/com/jishop/question/repository/QuestionCategoryRepository.java
+++ b/backend/JiShop/src/main/java/com/jishop/question/repository/QuestionCategoryRepository.java
@@ -1,0 +1,7 @@
+package com.jishop.question.repository;
+
+import com.jishop.question.domain.QuestionCategory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface QuestionCategoryRepository extends JpaRepository<QuestionCategory, Long> {
+}

--- a/backend/JiShop/src/main/java/com/jishop/question/repository/QuestionRepository.java
+++ b/backend/JiShop/src/main/java/com/jishop/question/repository/QuestionRepository.java
@@ -1,0 +1,13 @@
+package com.jishop.question.repository;
+
+import com.jishop.member.domain.User;
+import com.jishop.question.domain.Question;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface QuestionRepository extends JpaRepository<Question, Long> {
+    List<Question> findAllByUserIdOrderByCreatedAt(Long userId);
+}

--- a/backend/JiShop/src/main/java/com/jishop/question/repository/QuestionRepository.java
+++ b/backend/JiShop/src/main/java/com/jishop/question/repository/QuestionRepository.java
@@ -9,5 +9,6 @@ import java.util.List;
 
 @Repository
 public interface QuestionRepository extends JpaRepository<Question, Long> {
+
     List<Question> findAllByUserIdOrderByCreatedAt(Long userId);
 }

--- a/backend/JiShop/src/main/java/com/jishop/question/service/QuestionService.java
+++ b/backend/JiShop/src/main/java/com/jishop/question/service/QuestionService.java
@@ -1,0 +1,15 @@
+package com.jishop.question.service;
+
+import com.jishop.member.domain.User;
+import com.jishop.question.dto.QuestionRequest;
+import com.jishop.question.dto.QuestionResponse;
+import org.springframework.http.ResponseEntity;
+
+import java.util.List;
+
+public interface QuestionService {
+
+    Long createQuestion(QuestionRequest request, User user);
+    ResponseEntity<QuestionResponse> getQuestion(User user, Long questionId);
+    ResponseEntity<List<QuestionResponse>> getMyQuestion(User user);
+}

--- a/backend/JiShop/src/main/java/com/jishop/question/service/QuestionServiceImpl.java
+++ b/backend/JiShop/src/main/java/com/jishop/question/service/QuestionServiceImpl.java
@@ -100,7 +100,7 @@ public class QuestionServiceImpl implements QuestionService {
         return ResponseEntity.ok(
                 questions.stream()
                         .map(QuestionResponse::fromQuestion)
-                        .collect(Collectors.toList())
+                        .toList()
         );
     }
 }

--- a/backend/JiShop/src/main/java/com/jishop/question/service/QuestionServiceImpl.java
+++ b/backend/JiShop/src/main/java/com/jishop/question/service/QuestionServiceImpl.java
@@ -1,0 +1,106 @@
+package com.jishop.question.service;
+
+import com.jishop.common.exception.DomainException;
+import com.jishop.common.exception.ErrorType;
+import com.jishop.member.domain.User;
+import com.jishop.order.domain.Order;
+import com.jishop.order.repository.OrderRepository;
+import com.jishop.question.domain.Question;
+import com.jishop.question.domain.QuestionCategory;
+import com.jishop.question.dto.QuestionRequest;
+import com.jishop.question.dto.QuestionResponse;
+import com.jishop.question.repository.QuestionCategoryRepository;
+import com.jishop.question.repository.QuestionRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class QuestionServiceImpl implements QuestionService {
+
+    private final QuestionCategoryRepository questionCategoryRepository;
+    private final QuestionRepository questionRepository;
+    private final OrderRepository orderRepository;
+
+    /**
+     * 문의사항 작성에 필요한 데이터를 검증하고, Question 엔티티를 생성하는 메서드
+     * 
+     * @param request   문의사항 작성 DTO
+     * @param user      사용자 정보
+     * @return 생성된 Question id 
+     */
+    @Override
+    public Long createQuestion(QuestionRequest request, User user) {
+
+        // 카테고리 검증
+        QuestionCategory category = questionCategoryRepository.findById(request.categoryId())
+                .orElseThrow(() -> new DomainException(ErrorType.MATCH_NOT_USER));
+    
+        // 주문번호가 필수인 문의유형의 주문번호 검증
+        if(category.isRequireOrderNumber() && request.orderId() == null) {
+            throw new DomainException(ErrorType.QUESTION_ORDER_NUMBER_REQUIRED);
+        }
+
+        // 주문 정보 조회
+        Order order = null;
+        if(request.orderId() != null) {
+            order = orderRepository.findByOrderNumber(request.orderId())
+                    .orElseThrow(() -> new DomainException(ErrorType.ORDER_NOT_FOUND));
+
+            // 본인의 주문인지 조회
+            if(!order.getUserId().equals(user.getId())) {
+                throw new DomainException(ErrorType.MATCH_NOT_USER);
+            }
+        }
+
+        Question question = QuestionRequest.toEntity(request, category, user, order);
+        questionRepository.save(question);
+        return question.getId();
+    }
+
+    /**
+     * 문의사항 id로 해당 문의사항을 조회하는 메서드
+     *
+     * @param user          사용자 정보
+     * @param questionId    문의사항 id
+     * @return  사용자가 작성한 문의사항
+     */
+    @Override
+    @Transactional(readOnly = true)
+    public ResponseEntity<QuestionResponse> getQuestion(User user, Long questionId) {
+        Question question = questionRepository.findById(questionId)
+                .orElseThrow(() -> new DomainException(ErrorType.QUESTION_NOT_FOUND));
+
+        if(!question.getUser().getId().equals(user.getId())) {
+            throw new DomainException(ErrorType.MATCH_NOT_USER);
+        }
+
+        return ResponseEntity.ok(QuestionResponse.fromQuestion(question));
+    }
+
+    /**
+     * 사용자 정보를 기반으로 해당 사용자가 작성한 문의사항 조회 메서드
+     *
+     * @param user  사용자 정보
+     * @return 사용자가 작성한 문의사항 리스트
+     */
+    @Override
+    @Transactional(readOnly = true)
+    public ResponseEntity<List<QuestionResponse>> getMyQuestion(User user) {
+        List<Question> questions = questionRepository.findAllByUserIdOrderByCreatedAt(user.getId());
+
+        return ResponseEntity.ok(
+                questions.stream()
+                        .map(QuestionResponse::fromQuestion)
+                        .collect(Collectors.toList())
+        );
+    }
+}


### PR DESCRIPTION
<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- resolves #에는 발행한 이슈 번호를 기입해주세요 -->

- resolves #181 

---

### 🚀 어떤 기능을 구현했나요 ?
- 회원가입/로그인한 사용자만 문의사항 작성
- 본인이 작성한 문의사항만 조회 가능
- 관리자가 답변 작성 기능 구현❌

### 🔥 어떤 문제를 마주했나요 ?
- 문의사항 작성 시, 이미지 첨부 관련 문제

### ✨ 어떻게 해결했나요 ?
- 추후에 기획 및 디자인이 완료되면 수정할 예정
- 수정 시 `file`, `image` (author. @jihaneol )참고 후 수정

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 

### 📚 참고 자료 및 회고 
<!--참고 자료(ref) 링크 및 스크린샷, 구현 과정에 대한 회고-->

🍀 **문의사항 유형(카테고리)**
- 2뎁스로 구현
- 예를 들어 문의사항 유형이 `배송`인 경우, 하위에 아래와 같은 하위 유형이 존재
  - `배송일정`
  - `배송현황`
  - `배송문제`

🍀 **문의사항 레퍼런스**
https://www.notion.so/w-29cm-1c1cc686750c80798d5fdf298099fd23