### PR TITLE
[BE] feat: Swagger 수정 및 공지사항 검색 쿼리 수정

### DIFF
--- a/backend/JiShop/src/main/java/com/jishop/faq/controller/FaqController.java
+++ b/backend/JiShop/src/main/java/com/jishop/faq/controller/FaqController.java
@@ -6,7 +6,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PagedModel;
 import org.springframework.http.ResponseEntity;
 
-@Tag(name = "공지사항 API")
+@Tag(name = "FAQ API - 보류")
 public interface FaqController {
 
     ResponseEntity<PagedModel<FaqResponse>> getAllPopularFaqs(Pageable pageable);

--- a/backend/JiShop/src/main/java/com/jishop/notice/controller/NoticeController.java
+++ b/backend/JiShop/src/main/java/com/jishop/notice/controller/NoticeController.java
@@ -2,6 +2,7 @@ package com.jishop.notice.controller;
 
 import com.jishop.notice.dto.NoticeDetailResponse;
 import com.jishop.notice.dto.NoticeResponse;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PagedModel;
@@ -10,7 +11,12 @@ import org.springframework.http.ResponseEntity;
 @Tag(name = "공지사항 API")
 public interface NoticeController {
 
+    @Operation(summary = "공지사항 전체 조회", description = "공지사항 전체 목록을 조회")
     ResponseEntity<PagedModel<NoticeResponse>> getAllNotices(Pageable pageable);
+
+    @Operation(summary = "공지사항 조회", description = "공지사항 ID로 특정 공지사항 정보를 조회")
     ResponseEntity<NoticeDetailResponse> getNotice(Long id);
+
+    @Operation(summary = "공지사항 검색", description = "검색어를 통해 공지사항을 검색")
     ResponseEntity<PagedModel<NoticeResponse>> searchNotices(String keyword, Pageable pageable);
 }

--- a/backend/JiShop/src/main/java/com/jishop/notice/repository/NoticeRepository.java
+++ b/backend/JiShop/src/main/java/com/jishop/notice/repository/NoticeRepository.java
@@ -36,7 +36,7 @@ public interface NoticeRepository extends JpaRepository<Notice, Long> {
         // 공지사항 게시글에 키워드가 포함된 경우
         // 공지사항 제목에 키워드가 포함된 경우
     @Query("SELECT n FROM Notice n WHERE LOWER(n.title) LIKE LOWER(CONCAT('%', :keyword, '%')) " +
-            "OR LOWER(n.content) LOWER(CONCAT('%', :keyword, '%'))")
+            "OR LOWER(n.content) LIKE LOWER(CONCAT('%', :keyword, '%'))")
     Page<Notice> searchByKeyword(@Param("keyword")String keyword, Pageable pageable);
 
 }

--- a/backend/JiShop/src/main/java/com/jishop/notice/repository/NoticeRepository.java
+++ b/backend/JiShop/src/main/java/com/jishop/notice/repository/NoticeRepository.java
@@ -35,7 +35,8 @@ public interface NoticeRepository extends JpaRepository<Notice, Long> {
     // 검색 키워드 기반 공지사항 조회
         // 공지사항 게시글에 키워드가 포함된 경우
         // 공지사항 제목에 키워드가 포함된 경우
-    @Query("SELECT n FROM Notice n WHERE n.title LIKE %:keyword% OR n.content LIKE %:keyword%")
+    @Query("SELECT n FROM Notice n WHERE LOWER(n.title) LIKE LOWER(CONCAT('%', :keyword, '%')) " +
+            "OR LOWER(n.content) LOWER(CONCAT('%', :keyword, '%'))")
     Page<Notice> searchByKeyword(@Param("keyword")String keyword, Pageable pageable);
 
 }


### PR DESCRIPTION
<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- resolves #에는 발행한 이슈 번호를 기입해주세요 -->

- resolves #239 

---

### 🚀 어떤 기능을 구현했나요 ?
- Swagger 수정 
- 공지사항 검색 시 대소문자를 구분하지 않도록 쿼리 수정

```java
    @Query("SELECT n FROM Notice n WHERE LOWER(n.title) LIKE LOWER(CONCAT('%', :keyword, '%')) " +
            "OR LOWER(n.content) LIKE LOWER(CONCAT('%', :keyword, '%'))")
    Page<Notice> searchByKeyword(@Param("keyword")String keyword, Pageable pageable);

```


### 🔥 어떤 문제를 마주했나요 ?
-

### ✨ 어떻게 해결했나요 ?
- 

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 

### 📚 참고 자료 및 회고 
<!--참고 자료(ref) 링크 및 스크린샷, 구현 과정에 대한 회고-->
-
