### PR TITLE
[BE] 회원 수정 가능 관련 수정 및 회원 로그아웃 기능 재구현

### DIFF
--- a/backend/JiShop/src/main/java/com/jishop/member/controller/AuthController.java
+++ b/backend/JiShop/src/main/java/com/jishop/member/controller/AuthController.java
@@ -16,7 +16,7 @@ public interface AuthController {
     ResponseEntity<String> signIn(SignInFormRequest request, HttpServletRequest httpRequest,
                                   HttpServletResponse response);
     @Operation(summary = "회원 로그아웃")
-    ResponseEntity<Void> logout(HttpServletRequest request);
+    ResponseEntity<Void> logout(User user,HttpServletRequest request);
     @Operation(summary = "로그인 상태 체크")
     ResponseEntity<String> checkLogin(User user);
 }

--- a/backend/JiShop/src/main/java/com/jishop/member/controller/impl/AuthControllerImpl.java
+++ b/backend/JiShop/src/main/java/com/jishop/member/controller/impl/AuthControllerImpl.java
@@ -45,12 +45,13 @@ public class AuthControllerImpl implements AuthController {
     }
 
     @GetMapping("/logout")
-    public ResponseEntity<Void> logout(HttpServletRequest request) {
+    public ResponseEntity<Void> logout(@CurrentUser User user, HttpServletRequest request) {
         HttpSession session = request.getSession(false);
         if (session != null) {
             // redis의 세션도 삭제
             session.invalidate();
         }
+        service.logout(user);
         return ResponseEntity.ok().build();
     }
 

--- a/backend/JiShop/src/main/java/com/jishop/member/service/AuthService.java
+++ b/backend/JiShop/src/main/java/com/jishop/member/service/AuthService.java
@@ -19,4 +19,5 @@ public interface AuthService {
     Long checkLogin(User user);
     void updateAdSMSAgree(User user, UserAdSMSRequest request);
     void updateAdEmailAgree(User user, UserAdEmailRequest request);
+    void logout(User user);
 }


### PR DESCRIPTION
🔗 Resolves: #296

---

### 🚀 어떤 기능을 구현했나요 ?
- 회원 수정 기능

### 🔥 어떤 문제를 마주했나요 ?
- 현재 캐싱된 회원에 대한 정보수정이 계속될시 회원 정보 수정이 안되는 문제점 발견

### ✨ 어떻게 해결했나요 ?
- 회원 수정 같은 쓰기 기능일시 해당 회원 객체를 영속적인 상태로 사용해야하기에 해당 회원을 DB에서 조회한 후 DB에서 조회한 회원 사용

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 

### 📚 참고 자료 및 회고 
-
